### PR TITLE
ci: fix CodeQL race condition by triggering release via workflow_run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,10 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 on:
-  push:
-    branches:
-      - master
+  workflow_run:
+    workflows: ['CodeQL']
+    types: [completed]
+    branches: [master]
 
 permissions:
   contents: write
@@ -16,11 +17,13 @@ permissions:
 
 jobs:
   release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha }}
       - uses: actions/setup-node@v6
         with:
           node-version: '20'


### PR DESCRIPTION
Switch Release workflow from push to workflow_run on CodeQL completion so the merge commit already has CodeQL results when semantic-release pushes its release commit, avoiding GH013 branch protection errors.