### PR TITLE
ci: remove @semantic-release/git to avoid branch protection conflicts

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -14,22 +14,9 @@
       }
     ],
     [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md"
-      }
-    ],
-    [
       "@semantic-release/npm",
       {
         "npmPublish": true
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md", "package.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\\n\\n${nextRelease.notes}"
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
Dropping @semantic-release/changelog and @semantic-release/git so the release workflow no longer tries to push commits directly to master. Changelog is now published exclusively via GitHub Releases.