### PR TITLE
chore: reduce npm package size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ docs/
 schematics/dist/
 *.tgz
 firebase-debug.log
+.build-cache/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,27 @@
+# Source maps — not needed by consumers
+dist/**/*.js.map
+dist/**/*.d.ts.map
+
+# macOS metadata
+**/.DS_Store
+
+# Schematic source and tests (only compiled schematics/dist/ is needed)
+schematics/**/*.ts
+schematics/**/__mocks__/
+
+# Dev & CI config
+.github/
+src/
+examples/
+coverage/
+docs/
+*.tgz
+.env*
+tsconfig*.json
+jest.config.*
+eslint.config.*
+.commitlintrc*
+.prettierrc*
+.releaserc*
+simple-git-hooks*
+lint-staged*

--- a/package.json
+++ b/package.json
@@ -124,8 +124,13 @@
     "js-yaml": "^4.1.1"
   },
   "files": [
-    "dist/**",
-    "schematics/**",
+    "dist/cjs/**/*.js",
+    "dist/esm/**/*.js",
+    "dist/esm/**/*.d.ts",
+    "schematics/dist/**",
+    "schematics/whatsapp/collection.json",
+    "schematics/whatsapp/schema.json",
+    "schematics/whatsapp/files/",
     "README.md",
     "LICENSE"
   ],

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -2,6 +2,10 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/cjs",
-    "module": "commonjs"
+    "module": "commonjs",
+    "tsBuildInfoFile": ".build-cache/tsconfig.cjs.tsbuildinfo",
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false
   }
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "outDir": "dist/esm",
-    "module": "es2022"
+    "module": "es2022",
+    "tsBuildInfoFile": ".build-cache/tsconfig.esm.tsbuildinfo"
   }
 }


### PR DESCRIPTION
- Redirect .tsbuildinfo files to .build-cache/ to keep dist/ clean
- Disable declaration emit for CJS build (types entry points to ESM)
- Tighten package.json files field to explicit allowlist
- Add .npmignore for additional exclusions
- Add .build-cache/ to .gitignore